### PR TITLE
Evaluador pexp-t

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,24 @@
             "binaryPath": "/media/Win_drive/Users/diego/Documents/Materias UNISON/Estructuras de Datos/Examen02_Estructuras/test/imp.o",
             "binaryArgs": []
         }
-    ]
+    ],
+    "files.associations": {
+        "__bit_reference": "c",
+        "__functional_base": "c",
+        "__node_handle": "c",
+        "algorithm": "c",
+        "bitset": "c",
+        "chrono": "c",
+        "__memory": "c",
+        "functional": "c",
+        "iterator": "c",
+        "limits": "c",
+        "optional": "c",
+        "ratio": "c",
+        "system_error": "c",
+        "tuple": "c",
+        "type_traits": "c",
+        "vector": "c",
+        "memory": "c"
+    }
 }

--- a/include/imp.h
+++ b/include/imp.h
@@ -189,4 +189,7 @@ pexp_t *pexp_make_sequence(pexp_t *pfirst, pexp_t *psecond);
 pexp_t *pexp_make_cicle(bexp_t *condition, pexp_t *ptrue);
 pexp_t *pexp_make_conditional(bexp_t *condition, pexp_t *ptrue, pexp_t *pfalse);
 
+//Evaluador
+pexp_t *pexp_t_eval(pexp_t *p);
+
 #endif  /* ED_IMP_H_ */

--- a/include/imp.h
+++ b/include/imp.h
@@ -190,6 +190,6 @@ pexp_t *pexp_make_cicle(bexp_t *condition, pexp_t *ptrue);
 pexp_t *pexp_make_conditional(bexp_t *condition, pexp_t *ptrue, pexp_t *pfalse);
 
 //Evaluador
-pexp_t *pexp_t_eval(pexp_t *p);
+pexp_t *pexp_t_eval(pexp_t *p, mem_t* m);
 
 #endif  /* ED_IMP_H_ */

--- a/src/imp.c
+++ b/src/imp.c
@@ -431,11 +431,11 @@ void pexp_free(pexp_t *p) {
 }
 
 //Evaluador pexp_t
-pexp_t *pexp_t_eval(pexp_t *p)
+pexp_t *pexp_t_eval(pexp_t *p, mem_t* m)
 {
-    if(pexp_is_skip(p)) return pexp_make_skip();
-    if(pexp_is_ass(p)) return pexp_make_assign(p->index, p->rvalue);
-    if(pexp_is_sequence(p)) return pexp_make_sequence(p->pfirst, p->psecond);
-    if(pexp_is_while(p)) return pexp_make_cicle(p->condition, p->ptrue);
-    if(pexp_is_conditional(p)) return pexp_make_conditional(p->condition, p->ptrue, p->pfalse);
+    if(pexp_is_skip(p)) return pexp_t_eval(pexp_make_skip() ,m);
+    if(pexp_is_ass(p)) return pexp_t_eval(pexp_make_assign(p->index, p->rvalue), m);
+    if(pexp_is_sequence(p)) return pexp_t_eval(pexp_make_sequence(p->pfirst, p->psecond), m);
+    if(pexp_is_while(p)) return pexp_t_eval(pexp_make_cicle(p->condition, p->ptrue), m);
+    if(pexp_is_conditional(p)) return pexp_t_eval(pexp_make_conditional(p->condition, p->ptrue, p->pfalse), m);
 }

--- a/src/imp.c
+++ b/src/imp.c
@@ -430,3 +430,12 @@ void pexp_free(pexp_t *p) {
 
 }
 
+//Evaluador pexp_t
+pexp_t *pexp_t_eval(pexp_t *p)
+{
+    if(pexp_is_skip(p)) return pexp_make_skip();
+    if(pexp_is_ass(p)) return pexp_make_assign(p->index, p->rvalue);
+    if(pexp_is_sequence(p)) return pexp_make_sequence(p->pfirst, p->psecond);
+    if(pexp_is_while(p)) return pexp_make_cicle(p->condition, p->ptrue);
+    if(pexp_is_conditional(p)) return pexp_make_conditional(p->condition, p->ptrue, p->pfalse);
+}


### PR DESCRIPTION
Se evaluaron los predicados

pexp_is_skip(pexp_t *p)
pexp_is_ass(pexp_t *p)
pexp_is_sequence(pexp_t *p)
pexp_is_while(pexp_t *p)
pexp_is_conditional(pexp_t *p)

y retorna la evaluacion de los mismos utilizando sus respectivos constructores